### PR TITLE
Need to use 2.times.map when defining a has_many association

### DIFF
--- a/views/_content.markdown
+++ b/views/_content.markdown
@@ -304,7 +304,7 @@ For example, calling build on `person` will cascade down to `Fabricate(:car)`
 and they will not be persisted either.
 
     Fabricate.build(:person) do
-      cars { 2.times { Fabricate(:car) } }
+      cars { 2.times.map { Fabricate(:car) } }
     end
 
 #### Attributes Hash


### PR DESCRIPTION
Minor fix. Prior to this you'd get:

```
NoMethodError: undefined method `each' for 2:Fixnum
```
