### PR TITLE
[skip ci] Use correct Minitest test_framework generator option

### DIFF
--- a/source/index.markdown
+++ b/source/index.markdown
@@ -569,7 +569,7 @@ end
 
 ```ruby
 config.generators do |g|
-  g.test_framework      :mini_test, fixture_replacement: :fabrication
+  g.test_framework      :minitest, fixture_replacement: :fabrication
   g.fixture_replacement :fabrication, dir: "test/fabricators"
 end
 ```


### PR DESCRIPTION
When running a generator with the documented Minitest configuration, an error is thrown: `error    mini_test [not found]`. This updates the test_framework with the correct symbol.